### PR TITLE
feat(security): JWT 인증 필터 적용 및 사용자 정보 조회 방식 수정

### DIFF
--- a/src/main/java/com/groom/MAPro/Controller/UserPreferenceController.java
+++ b/src/main/java/com/groom/MAPro/Controller/UserPreferenceController.java
@@ -13,6 +13,7 @@ import com.groom.MAPro.entity.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import javax.swing.text.html.Option;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class UserPreferenceController {
         User user = userRepository.findByUsername(userDetails.getUsername())
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        var optionIds = preferenceService.getUserPreferences(user).stream()
+        List<Long> optionIds = preferenceService.getUserPreferences(user).stream()
                 .filter(UserPreference::getIsSelected)
                 .map(pref -> pref.getOption().getOptionId())
                 .collect(Collectors.toList());

--- a/src/main/java/com/groom/MAPro/config/SecurityConfig.java
+++ b/src/main/java/com/groom/MAPro/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import com.groom.MAPro.util.JwtUtil;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -38,8 +39,7 @@ public class SecurityConfig {
                     "/api/auth/login",
                     "/api/auth/test",
                     "/api/auth/",
-                    "/api/map/**",
-                        "/api/user/**"
+                    "/api/map/**"
                     
                 ).permitAll()
                 
@@ -47,26 +47,23 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/user/**",          // 사용자 정보 관련
                     "/api/profile/**",       // 프로필 관련
-                    "/api/protected/**"      // 기타 보호된 리소스
+                    "/api/protected/**",      // 기타 보호된 리소스
+                         "/api/user/**"
                 ).authenticated()
-                
-                // 나머지 모든 요청은 인증 필요
-                .anyRequest().authenticated()
-            );
-
-        // JWT 필터 추가 (JWT 인증을 사용한다면)
-        // .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
-
+                    .anyRequest().authenticated()
+            )
+                    // JWT 필터 추가 (JWT 인증을 사용한다면)
+                     .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
     // JWT 필터 (나중에 필요할 때 주석 해제)
-    /*
+
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
         return new JwtAuthenticationFilter(jwtUtil);
     }
-    */
+
 }
 
 /*

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,4 @@
 #spring.profiles.active=prod
 
 spring.application.name=MAPro
-spring.profiles.active=dev
+spring.profiles.active=local


### PR DESCRIPTION
- JwtAuthenticationFilter를 SecurityConfig에 등록하여 모든 요청에 JWT 인증 적용
- SecurityContext에 email 기반 Authentication 저장하도록 구현
- 컨트롤러에서 @AuthenticationPrincipal 대신 Authentication 파라미터로 사용자 정보(email) 조회
- User 조회 시 authentication.getName()을 통해 인증된 사용자 email 활용